### PR TITLE
fix: 通过try catch办法捕获getUid方法中的异常，在异常状态下提前终止染色判断

### DIFF
--- a/packages/open-platform-plugin/index.js
+++ b/packages/open-platform-plugin/index.js
@@ -86,9 +86,15 @@ class OpenPlatformPlugin {
      */
     eventBus.on("REQUEST_START", (payload) => {
       const { req, context } = payload;
-    
-      context.uid = this.getUid(req);
-    
+      try{
+        context.uid = this.getUid(req);
+      } catch(e) {
+        context.uid = null;
+        this.log(`获取uid失败: ${e}`);
+      }
+      if(context.uid === null) {
+        return;
+      }
       // 1. 判断是否命中开放平台配置的代理名单
       for (const proxyIp of Object.keys(this.proxyInfo)) {
         if ((this.proxyInfo[proxyIp].remoteAlphaList && this.proxyInfo[proxyIp].remoteAlphaList.includes(context.uid))

--- a/packages/open-platform-plugin/index.js
+++ b/packages/open-platform-plugin/index.js
@@ -86,6 +86,12 @@ class OpenPlatformPlugin {
      */
     eventBus.on("REQUEST_START", (payload) => {
       const { req, context } = payload;
+
+      this.log(`${req.method} ${req.url}`);
+      this.log(`server ip: ${this.intranetIp}, `
+        + `tcp: ${(req.socket.remoteAddress)}:${(req.socket.remotePort)} `
+        + `> ${(req.socket.localAddress)}:${(req.socket.localPort)}, client ip: ${this.getUserIp(req)}`);
+
       try{
         context.uid = this.getUid(req);
       } catch(e) {
@@ -111,11 +117,6 @@ class OpenPlatformPlugin {
         && this.proxyInfo[this.intranetIp].alphaList.includes(context.uid)) {
         context.proxyIp = "alpha"; // 不转发，但抓包
       }
-
-      this.log(`${req.method} ${req.url}`);
-      this.log(`server ip: ${this.intranetIp}, `
-        + `tcp: ${(req.socket.remoteAddress)}:${(req.socket.remotePort)} `
-        + `> ${(req.socket.localAddress)}:${(req.socket.localPort)}, client ip: ${this.getUserIp(req)}`);
     })
     
     /**


### PR DESCRIPTION
改动点：packages/open-platform-plugin/index.js文件
操作：对context.uid = this.getUid(req);进行了try catch
解释：如果没有报错没有获取到uid，直接不用执行代理白名单和本地名单的判断了（没有必要执行）