### PR TITLE
feat: appid 和 appkey 使用环境变量的形式传入 #10

### DIFF
--- a/packages/open-platform-api/README.md
+++ b/packages/open-platform-api/README.md
@@ -11,8 +11,7 @@ Open api for https://tswjs.org
 const { OpenApi } = require("@tswjs/open-platform-api");
 
 const client = new OpenApi({
-  appid: "appid",
-  appkey: "appkey"
+  httpDomain: 'http',
 });
 
 /**

--- a/packages/open-platform-api/README.md
+++ b/packages/open-platform-api/README.md
@@ -54,3 +54,12 @@ client.removeTestUid(uinList).then(d => {
   console.error(e);
 });
 ```
+
+‼️ 重要
+
+2.0版本以后，不再允许将开放平台申请的 `appid` 和 `appkey` 通过参数的形式透传到插件中。业务可以选择用合适的方式将这两个参数挂载到环境变量当中，对应形式如下且环境变量的名称不可更改：
+
+```
+appid => process.env.APP_ID
+appkey =>  process.env.APP_KEY
+```

--- a/packages/open-platform-api/lib/openapi.js
+++ b/packages/open-platform-api/lib/openapi.js
@@ -13,14 +13,12 @@ class OpenApi {
   /**
    * 调用openapi依赖的参数
    * @param {*} options 参数对象
-   * @param {string} options.appid 应用 id
-   * @param {string} options.appkey 应用 key
    * @param {string} options.httpDomain 是否使用 http 上报域名
    */
   constructor(options = {}) {
     this.apiDomain = "openapi.tswjs.org";
-    this.appid = options.appid
-    this.appkey = options.appkey;
+    this.appid = process.env.APP_ID;
+    this.appkey = process.env.APP_KEY;
     this.apiPrefix = `${options.httpDomain ? "http" : "https"}://${this.apiDomain}`;
 
     this.logReportUrl = `${this.apiPrefix}/v1/log/report`;

--- a/packages/open-platform-plugin/README.md
+++ b/packages/open-platform-plugin/README.md
@@ -62,8 +62,8 @@ module.exports = {
 
 2.0版本以后，不再允许将开放平台申请的 `appid` 和 `appkey` 通过参数的形式透传到插件中。业务可以选择用合适的方式将这两个参数挂载到环境变量当中，对应形式如下且环境变量的名称不可更改：
 ```
-appid: process.env.APP_ID
-appkey: process.env.APP_KEY
+appid => process.env.APP_ID
+appkey =>  process.env.APP_KEY
 ```
 
 插件也支持传入环境变量(`*.env`)配置文件，在插件初始化阶段会将值挂载到环境变量上。

--- a/packages/open-platform-plugin/README.md
+++ b/packages/open-platform-plugin/README.md
@@ -14,8 +14,7 @@ const OpenPlatformPlugin = require("@tswjs/open-platform-plugin");
 module.exports = {
   plugins: [
     new OpenPlatformPlugin({
-      appid: "tsw1431",
-      appkey: "PwPaD4RRAsrSdRZjQSc3fbKM",
+      envPath: 'platform.env'
       reportStrategy: "always",
       // 只支持同步写法
       getUid: (request) => {
@@ -59,19 +58,26 @@ module.exports = {
 
 ## Config
 
-### `appid`
+### ‼️ 重要
 
+2.0版本以后，不再允许将开放平台申请的 `appid` 和 `appkey` 通过参数的形式透传到插件中。业务可以选择用合适的方式将这两个参数挂载到环境变量当中，对应形式如下且环境变量的名称不可更改：
+```
+appid: process.env.APP_ID
+appkey: process.env.APP_KEY
+```
+
+插件也支持传入环境变量(`*.env`)配置文件，在插件初始化阶段会将值挂载到环境变量上。
+
+### `envPath`
 - `String`
-- 必填
+- 非必填，本地绝对路径或相对路径（`process.cwd() + relativePath`）
+- 默认值: `.env`
 
-项目在 [TSW 开放平台](https://tswjs.org) 申请的应用 id。
-
-### `appkey`
-
-- `String`
-- 必填
-
-项目在 [TSW 开放平台](https://tswjs.org) 申请的应用 key。
+```js
+// platform.env
+APP_KEY=your_app_key
+APP_ID=your_app_id
+```
 
 ### `reportStrategy`
 

--- a/packages/open-platform-plugin/index.js
+++ b/packages/open-platform-plugin/index.js
@@ -1,12 +1,14 @@
 const { OpenApi } = require('@tswjs/open-platform-api');
 const ip = require("ip");
 const net = require("net");
+const dotenv = require('dotenv');
+
+const DEFAULT_ENV_PATH = '.env';
 
 class OpenPlatformPlugin {
   /**
    * @param {Object} config 配置对象
-   * @param {String} config.appid 应用 id
-   * @param {String} config.appkey 应用 key
+   * @param {String} config.envPath 业务环境变量配置
    * @param {"never" | "always" | "proxied"} config.reportStrategy 上报策略
    * @param {Function} config.getUid 获取用户唯一标识
    * @param {Function} config.getProxyInfo 获取本机代理环境信息
@@ -21,11 +23,11 @@ class OpenPlatformPlugin {
     this.proxyInfo = {};
     this.intranetIp = ip.address();
 
+    this.initEnv(config.envPath);
+
     this.openApi = new OpenApi({
-      appid: config.appid,
-      appkey: config.appkey,
       httpDomain: config.httpDomain
-    })
+    });
 
     // 默认给一个返回 undefined 的同步函数
     this.getUid = config.getUid || (() => {});
@@ -33,6 +35,16 @@ class OpenPlatformPlugin {
     this.getProxyInfo = config.getProxyInfo || (() => {});
     // 回调函数
     this.hooks = config.hooks || {}
+  }
+
+  initEnv(configEnvPath) {
+    let envPath = DEFAULT_ENV_PATH;
+    if (configEnvPath) {
+      envPath = configEnvPath;
+    }
+    dotenv.config({
+      path: envPath,
+    });
   }
 
   /**

--- a/packages/open-platform-plugin/package-lock.json
+++ b/packages/open-platform-plugin/package-lock.json
@@ -4,6 +4,11 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"dotenv": {
+			"version": "14.2.0",
+			"resolved": "https://mirrors.tencent.com/npm/dotenv/-/dotenv-14.2.0.tgz",
+			"integrity": "sha512-05POuPJyPpO6jqzTNweQFfAyMSD4qa4lvsMOWyTRTdpHKy6nnnN+IYWaXF+lHivhBH/ufDKlR4IWCAN3oPnHuw=="
+		},
 		"ip": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",

--- a/packages/open-platform-plugin/package.json
+++ b/packages/open-platform-plugin/package.json
@@ -4,6 +4,7 @@
   "main": "./index.js",
   "dependencies": {
     "@tswjs/open-platform-api": "^1.2.4",
+    "dotenv": "^14.2.0",
     "ip": "^1.1.5"
   },
   "scripts": {


### PR DESCRIPTION
BREAKING CHANGE: `appid` 和 `appkey` 不再支持参数的形式传入，仅支持环境变量或者`.env`的方式进行设置